### PR TITLE
Guard debug/trace calls where necessary to avoid method calls

### DIFF
--- a/src/main/java/com/teragrep/k8s_01/K8SConsumer.java
+++ b/src/main/java/com/teragrep/k8s_01/K8SConsumer.java
@@ -61,20 +61,22 @@ public class K8SConsumer implements Consumer<FileRecord> {
     public void accept(FileRecord record) {
 
             UUID uuid = java.util.UUID.randomUUID();
-            LOGGER.debug(
-                    "[{}] Got a new record from file: {}/{}",
-                    uuid,
-                    record.getPath(),
-                    record.getFilename()
-            );
-            LOGGER.debug(
-                    "[{}] Reading {} starting from {}, file progress {}/{}",
-                    uuid,
-                    record.getRecord().length,
-                    record.getStartOffset(),
-                    (int) (record.getStartOffset()+record.getRecord().length),
-                    record.getEndOffset()
-            );
+            if(LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "[{}] Got a new record from file: {}/{}",
+                        uuid,
+                        record.getPath(),
+                        record.getFilename()
+                );
+                LOGGER.debug(
+                        "[{}] Reading {} starting from {}, file progress {}/{}",
+                        uuid,
+                        record.getRecord().length,
+                        record.getStartOffset(),
+                        (int) (record.getStartOffset() + record.getRecord().length),
+                        record.getEndOffset()
+                );
+            }
             KubernetesLogFilePOJO log;
             try {
                 // We want to read the kubernetes log event into a POJO, mostly for the timestamp
@@ -163,15 +165,18 @@ public class K8SConsumer implements Consumer<FileRecord> {
                         appConfig.getKubernetes().getLabels().getAppname().getFallback()
                 );
             }
-            LOGGER.debug(
-                    "[{}] Resolved message to be {}@{} from {}/{} generated at {}",
-                    uuid,
-                    appname,
-                    hostname,
-                    namespace,
-                    podname,
-                    log.getTime()
-            );
+
+            if(LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "[{}] Resolved message to be {}@{} from {}/{} generated at {}",
+                        uuid,
+                        appname,
+                        hostname,
+                        namespace,
+                        podname,
+                        log.getTime()
+                );
+            }
 
             // Craft syslog message and structured-data
             SDElement SDMetadata = new SDElement("kubernetesmeta@48577")

--- a/src/main/java/com/teragrep/k8s_01/KubernetesCachingAPIClient.java
+++ b/src/main/java/com/teragrep/k8s_01/KubernetesCachingAPIClient.java
@@ -82,11 +82,13 @@ class KubernetesCachingAPIClient {
 
         RemovalListener<HashMap<String, String>, PodMetadataContainer> listener = removalNotification -> {
             if (removalNotification.wasEvicted()) {
-                LOGGER.debug(
-                        "Evicted pod {} from cache: {}",
-                        removalNotification.getKey(),
-                        removalNotification.getCause().name()
-                );
+                if(LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
+                            "Evicted pod {} from cache: {}",
+                            removalNotification.getKey(),
+                            removalNotification.getCause().name()
+                    );
+                }
             }
         };
         podCache = CacheBuilder
@@ -112,11 +114,13 @@ class KubernetesCachingAPIClient {
 
         RemovalListener<String, NamespaceMetadataContainer> listener = removalNotification -> {
             if (removalNotification.wasEvicted()) {
-                LOGGER.debug(
-                        "Evicted namespace {} from cache: {}",
-                        removalNotification.getKey(),
-                        removalNotification.getCause().name()
-                );
+                if(LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
+                            "Evicted namespace {} from cache: {}",
+                            removalNotification.getKey(),
+                            removalNotification.getCause().name()
+                    );
+                }
             }
         };
         namespaceCache = CacheBuilder

--- a/src/main/java/com/teragrep/k8s_01/KubernetesLogReader.java
+++ b/src/main/java/com/teragrep/k8s_01/KubernetesLogReader.java
@@ -17,20 +17,10 @@
 
 package com.teragrep.k8s_01;
 
-import com.cloudbees.syslog.Facility;
-import com.cloudbees.syslog.SDElement;
-import com.cloudbees.syslog.Severity;
-import com.cloudbees.syslog.SyslogMessage;
 import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
 import com.teragrep.k8s_01.config.AppConfig;
-import com.teragrep.k8s_01.metadata.KubernetesMetadata;
-import com.teragrep.k8s_01.metadata.NamespaceMetadataContainer;
-import com.teragrep.k8s_01.metadata.PodMetadataContainer;
 import com.teragrep.rlo_12.DirectoryEventWatcher;
-import com.teragrep.rlo_13.FileRecord;
 import com.teragrep.rlo_13.StatefulFileReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,8 +31,6 @@ import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 public class KubernetesLogReader {
@@ -164,11 +152,13 @@ public class KubernetesLogReader {
 
         // FIXME: Is this necessary
         for (Thread thread : threads) {
-            LOGGER.trace(
-                    "Waiting for thread {}#{} to finish",
-                    thread.getName(),
-                    thread.getId()
-            );
+            if(LOGGER.isTraceEnabled()) {
+                LOGGER.trace(
+                        "Waiting for thread {}#{} to finish",
+                        thread.getName(),
+                        thread.getId()
+                );
+            }
             try {
                 thread.join();
             } catch (InterruptedException e) {

--- a/src/main/java/com/teragrep/k8s_01/RelpOutput.java
+++ b/src/main/java/com/teragrep/k8s_01/RelpOutput.java
@@ -37,16 +37,20 @@ public class RelpOutput {
     RelpOutput(AppConfigRelp appConfigRelp, int threadId) {
         relpConfig = appConfigRelp;
         id = threadId;
-        LOGGER.debug(
-                "[#{}] Started Relp thread #{}",
-                getId(),
-                getId()
-        );
-        LOGGER.trace(
-                "[#{}] Received Relp config: {}",
-                getId(),
-                relpConfig
-        );
+        if(LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "[#{}] Started Relp thread #{}",
+                    getId(),
+                    getId()
+            );
+        }
+        if(LOGGER.isTraceEnabled()) {
+            LOGGER.trace(
+                    "[#{}] Received Relp config: {}",
+                    getId(),
+                    relpConfig
+            );
+        }
         relpConnection = new RelpConnection();
         relpConnection.setConnectionTimeout(relpConfig.getConnectionTimeout());
         relpConnection.setReadTimeout(relpConfig.getReadTimeout());
@@ -58,12 +62,14 @@ public class RelpOutput {
         boolean connected = false;
         while (!connected) {
             try {
-                LOGGER.debug(
-                        "[#{}] Connecting to {}:{}",
-                        getId(),
-                        relpConfig.getTarget(),
-                        relpConfig.getPort()
-                );
+                if(LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
+                            "[#{}] Connecting to {}:{}",
+                            getId(),
+                            relpConfig.getTarget(),
+                            relpConfig.getPort()
+                    );
+                }
                 connected = relpConnection.connect(relpConfig.getTarget(), relpConfig.getPort());
             } catch (IOException | TimeoutException e) {
                 LOGGER.error(
@@ -105,27 +111,33 @@ public class RelpOutput {
     }
 
     public void send(SyslogMessage syslogMessage) {
-        LOGGER.debug(
-                "[#{}] Got a new message from {}@{}",
-                getId(),
-                syslogMessage.getAppName(),
-                syslogMessage.getHostname()
-        );
-        LOGGER.trace(
-                "[#{}] Sending message: {}",
-                getId(),
-                syslogMessage.toRfc5424SyslogMessage()
-        );
+        if(LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "[#{}] Got a new message from {}@{}",
+                    getId(),
+                    syslogMessage.getAppName(),
+                    syslogMessage.getHostname()
+            );
+        }
+        if(LOGGER.isTraceEnabled()) {
+            LOGGER.trace(
+                    "[#{}] Sending message: {}",
+                    getId(),
+                    syslogMessage.toRfc5424SyslogMessage()
+            );
+        }
         RelpBatch batch = new RelpBatch();
         batch.insert(syslogMessage.toRfc5424SyslogMessage().getBytes(StandardCharsets.UTF_8));
 
         boolean allSent = false;
         while (!allSent) {
             try {
-                LOGGER.trace(
-                        "[#{}] Committing batch",
-                        getId()
-                );
+                if(LOGGER.isTraceEnabled()) {
+                    LOGGER.trace(
+                            "[#{}] Committing batch",
+                            getId()
+                    );
+                }
                 relpConnection.commit(batch);
             } catch (IllegalStateException | IOException | java.util.concurrent.TimeoutException e) {
                 LOGGER.error(


### PR DESCRIPTION
Did not touch stuff inside error handling, or info/warn level logging messages. Note for reviewing is to check if there are calls that still needs to be guarded