### PR TITLE
Adds stream label switching mechanism

### DIFF
--- a/etc/config.json
+++ b/etc/config.json
@@ -10,13 +10,15 @@
     "labels": {
       "hostname": {
         "prefix": "prefix-",
-        "label": "host",
-        "fallback": "fallback-hostname"
+        "fallback": "fallback-hostname",
+        "labelStdout": "host",
+        "labelStderr": "host-stderr"
       },
       "appname": {
         "prefix": "prefix-",
-        "label": "app",
-        "fallback": "fallback-appname"
+        "fallback": "fallback-appname",
+        "labelStdout": "app",
+        "labelStderr":  "app-stderr"
       }
     },
     "logfiles": [

--- a/example/combined.yaml
+++ b/example/combined.yaml
@@ -47,13 +47,15 @@ data:
         "labels": {
           "hostname": {
             "prefix": "prefix-",
-            "label": "host",
-            "fallback": "fallback-hostname"
+            "fallback": "fallback-hostname",
+            "labelStdout": "host",
+            "labelStderr": "host-stderr"
           },
           "appname": {
             "prefix": "prefix-",
-            "label": "app",
-            "fallback": "fallback-appname"
+            "fallback": "fallback-appname",
+            "labelStdout": "app",
+            "labelStderr":  "app-stderr"
           }
         },
         "logfiles": [
@@ -101,7 +103,7 @@ data:
     </Configuration>
 kind: ConfigMap
 metadata:
-  name: app-config-td2t2mhm2c
+  name: app-config-9m5c6kk4c8
 ---
 apiVersion: v1
 kind: Secret
@@ -132,7 +134,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: first-pod-hostname
+    app: first-pod-appname
+    app-stderr: first-pod-appname-stderr
     env: dev
   name: first-pod
   namespace: default
@@ -140,7 +143,8 @@ spec:
   containers:
   - args:
     - -c
-    - echo 'I am first pod'; echo 'This is an example log message'; sleep inf;
+    - echo 'I am first pod'; echo 'This is an example log message'; echo 'This is
+      something to stderr' >&2; sleep inf;
     command:
     - /usr/bin/bash
     image: rockylinux:8
@@ -224,7 +228,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - configMap:
-      name: app-config-td2t2mhm2c
+      name: app-config-9m5c6kk4c8
     name: app-config
   - hostPath:
       path: /var/log/containers
@@ -298,13 +302,15 @@ metadata:
     app: third-pod-app
     env: dev
     host: third-pod-hostname
+    host-stderr: third-pod-hostname-stderr
   name: third-pod
   namespace: default
 spec:
   containers:
   - args:
     - -c
-    - 'echo ''I am third pod #1''; echo ''I will not print more logs''; sleep inf'
+    - 'echo ''I am third pod #1''; echo ''I will not print more logs'' >&2; sleep
+      inf'
     command:
     - /usr/bin/bash
     image: rockylinux:8

--- a/example/config/config.json
+++ b/example/config/config.json
@@ -10,13 +10,15 @@
     "labels": {
       "hostname": {
         "prefix": "prefix-",
-        "label": "host",
-        "fallback": "fallback-hostname"
+        "fallback": "fallback-hostname",
+        "labelStdout": "host",
+        "labelStderr": "host-stderr"
       },
       "appname": {
         "prefix": "prefix-",
-        "label": "app",
-        "fallback": "fallback-appname"
+        "fallback": "fallback-appname",
+        "labelStdout": "app",
+        "labelStderr":  "app-stderr"
       }
     },
     "logfiles": [

--- a/example/pods/first-pod.json
+++ b/example/pods/first-pod.json
@@ -3,7 +3,8 @@
     "name": "first-pod",
     "namespace": "default",
     "labels": {
-      "app": "first-pod-hostname",
+      "app": "first-pod-appname",
+      "app-stderr": "first-pod-appname-stderr",
       "env": "dev"
     }
   },
@@ -23,7 +24,7 @@
         ],
         "args": [
           "-c",
-          "echo 'I am first pod'; echo 'This is an example log message'; sleep inf;"
+          "echo 'I am first pod'; echo 'This is an example log message'; echo 'This is something to stderr' >&2; sleep inf;"
         ]
       }
     ],

--- a/example/pods/third-pod.json
+++ b/example/pods/third-pod.json
@@ -4,6 +4,7 @@
     "namespace": "default",
     "labels": {
       "host": "third-pod-hostname",
+      "host-stderr": "third-pod-hostname-stderr",
       "app": "third-pod-app",
       "env": "dev"
     }
@@ -24,7 +25,7 @@
         ],
         "args": [
           "-c",
-          "echo 'I am third pod #1'; echo 'I will not print more logs'; sleep inf"
+          "echo 'I am third pod #1'; echo 'I will not print more logs' >&2; sleep inf"
         ]
       },
       {

--- a/src/main/java/com/teragrep/k8s_01/K8SConsumer.java
+++ b/src/main/java/com/teragrep/k8s_01/K8SConsumer.java
@@ -157,11 +157,11 @@ public class K8SConsumer implements Consumer<FileRecord> {
             }
             else {
                 hostname = podMetadataContainer.getLabels().getOrDefault(
-                        appConfig.getKubernetes().getLabels().getHostname().getLabel(),
+                        appConfig.getKubernetes().getLabels().getHostname().getLabel(log.getStream()),
                         appConfig.getKubernetes().getLabels().getHostname().getFallback()
                 );
                 appname = podMetadataContainer.getLabels().getOrDefault(
-                        appConfig.getKubernetes().getLabels().getAppname().getLabel(),
+                        appConfig.getKubernetes().getLabels().getAppname().getLabel(log.getStream()),
                         appConfig.getKubernetes().getLabels().getAppname().getFallback()
                 );
             }

--- a/src/main/java/com/teragrep/k8s_01/config/AppConfigLabel.java
+++ b/src/main/java/com/teragrep/k8s_01/config/AppConfigLabel.java
@@ -37,7 +37,7 @@ public class AppConfigLabel {
     public String getLabel(String label) {
         if(label.equals("stderr") && labelStderr != null) {
             return labelStderr;
-        });
+        }
         return labelStdout;
     }
 

--- a/src/main/java/com/teragrep/k8s_01/config/AppConfigLabel.java
+++ b/src/main/java/com/teragrep/k8s_01/config/AppConfigLabel.java
@@ -22,19 +22,23 @@ import com.google.gson.Gson;
 /* POJO representing the .kubernetes.labels.{hostname,appname} part of config.json */
 public class AppConfigLabel {
     private String prefix;
-    private String label;
     private String fallback;
+    private String labelStdout;
+    private String labelStderr;
 
     public String getPrefix() {
         return prefix;
     }
 
-    public String getLabel() {
-        return label;
-    }
-
     public String getFallback() {
         return fallback;
+    }
+
+    public String getLabel(String label) {
+        if(label.equals("stderr") && labelStderr != null) {
+            return labelStderr;
+        });
+        return labelStdout;
     }
 
     @Override


### PR DESCRIPTION
Logic: Checks streams when getting labels, uses labelStderr on stderr streams if it is not null, otherwise falls back to labelStdout.

So by having

```json
"labelStdout": "app",
"labelStderr":  "app-stderr"
```

and labels

```json
"labels": {
  "app": "k8s_01",
  "host": "k8s_01",
  "env": "dev"
}
```

It will use `k8s_01` as appname since `app-stderr` doesn't exist, but in

```json
"labels": {
  "app": "k8s_01",
  "app-stderr": "stderrstream",
  "host": "k8s_01",
  "env": "dev"
}
````

it would use `stderrstream` as appname.